### PR TITLE
Update sapling_crypto to fil_sapling_crypto in 'use'.

### DIFF
--- a/benches/pedersen_hash.rs
+++ b/benches/pedersen_hash.rs
@@ -7,8 +7,8 @@ extern crate test;
 
 use paired::bls12_381::Bls12;
 use rand::{thread_rng, Rand};
-use sapling_crypto::jubjub::JubjubBls12;
-use sapling_crypto::pedersen_hash::{pedersen_hash, Personalization};
+use fil_sapling_crypto::jubjub::JubjubBls12;
+use fil_sapling_crypto::pedersen_hash::{pedersen_hash, Personalization};
 
 #[bench]
 fn bench_pedersen_hash(b: &mut test::Bencher) {


### PR DESCRIPTION
Hanging update from the rename — needed so pedersen hash benchmark will build.