### PR TITLE
Change pedersen_hash_exp_window_size to 16.

### DIFF
--- a/benches/pedersen_hash.rs
+++ b/benches/pedersen_hash.rs
@@ -10,12 +10,22 @@ use rand::{thread_rng, Rand};
 use fil_sapling_crypto::jubjub::JubjubBls12;
 use fil_sapling_crypto::pedersen_hash::{pedersen_hash, Personalization};
 
-#[bench]
-fn bench_pedersen_hash(b: &mut test::Bencher) {
-    let params = JubjubBls12::new();
+fn bench_pedersen_hash_aux(b: &mut test::Bencher, params: JubjubBls12) {
     let rng = &mut thread_rng();
     let bits = (0..510).map(|_| bool::rand(rng)).collect::<Vec<_>>();
     let personalization = Personalization::MerkleTree(31);
 
     b.iter(|| pedersen_hash::<Bls12, _>(personalization, bits.clone(), &params));
+}
+
+#[bench]
+fn bench_pedersen_hash(b: &mut test::Bencher) {
+    let params = JubjubBls12::new();
+    bench_pedersen_hash_aux(b, params);
+}
+
+#[bench]
+fn bench_pedersen_hash_16(b: &mut test::Bencher) {
+    let params = JubjubBls12::new_with_window_size(16);
+    bench_pedersen_hash_aux(b, params);
 }

--- a/benches/pedersen_hash.rs
+++ b/benches/pedersen_hash.rs
@@ -29,3 +29,21 @@ fn bench_pedersen_hash_16(b: &mut test::Bencher) {
     let params = JubjubBls12::new_with_window_size(16);
     bench_pedersen_hash_aux(b, params);
 }
+
+#[bench]
+fn bench_pedersen_hash_17(b: &mut test::Bencher) {
+    let params = JubjubBls12::new_with_window_size(17);
+    bench_pedersen_hash_aux(b, params);
+}
+
+#[bench]
+fn bench_pedersen_hash_18(b: &mut test::Bencher) {
+    let params = JubjubBls12::new_with_window_size(18);
+    bench_pedersen_hash_aux(b, params);
+}
+
+#[bench]
+fn bench_pedersen_hash_19(b: &mut test::Bencher) {
+    let params = JubjubBls12::new_with_window_size(19);
+    bench_pedersen_hash_aux(b, params);
+}

--- a/src/circuit/pedersen_hash.rs
+++ b/src/circuit/pedersen_hash.rs
@@ -121,7 +121,7 @@ mod test {
     #[test]
     fn test_pedersen_hash_constraints() {
         let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
-        let params = &JubjubBls12::new();
+        let params = &JubjubBls12::new_with_window_size(16);
         let mut cs = TestConstraintSystem::<Bls12>::new();
 
         let input: Vec<bool> = (0..(Fr::NUM_BITS * 2)).map(|_| rng.gen()).collect();
@@ -151,7 +151,7 @@ mod test {
     #[test]
     fn test_pedersen_hash() {
         let mut rng = XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
-        let params = &JubjubBls12::new();
+        let params = &JubjubBls12::new_with_window_size(16);
 
         for length in 0..751 {
             for _ in 0..5 {

--- a/src/circuit/pedersen_hash.rs
+++ b/src/circuit/pedersen_hash.rs
@@ -155,7 +155,7 @@ mod test {
 
         for length in 0..751 {
             for _ in 0..5 {
-                let mut input: Vec<bool> = (0..length).map(|_| rng.gen()).collect();
+                let input: Vec<bool> = (0..length).map(|_| rng.gen()).collect();
 
                 let mut cs = TestConstraintSystem::<Bls12>::new();
 

--- a/src/circuit/uint32.rs
+++ b/src/circuit/uint32.rs
@@ -398,7 +398,7 @@ mod test {
         let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0653]);
 
         for _ in 0..1000 {
-            let mut v = (0..32)
+            let v = (0..32)
                 .map(|_| Boolean::constant(rng.gen()))
                 .collect::<Vec<_>>();
 
@@ -430,7 +430,7 @@ mod test {
         let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0653]);
 
         for _ in 0..1000 {
-            let mut v = (0..32)
+            let v = (0..32)
                 .map(|_| Boolean::constant(rng.gen()))
                 .collect::<Vec<_>>();
 

--- a/src/jubjub/mod.rs
+++ b/src/jubjub/mod.rs
@@ -181,7 +181,7 @@ impl JubjubParams<Bls12> for JubjubBls12 {
         &self.fixed_base_circuit_generators[base as usize][..]
     }
     fn pedersen_hash_exp_window_size() -> u32 {
-        8
+        16
     }
 }
 

--- a/src/pedersen_hash.rs
+++ b/src/pedersen_hash.rs
@@ -84,7 +84,7 @@ where
 
         let mut table: &[Vec<edwards::Point<E, _>>] =
             &generators.next().expect("we don't have enough generators");
-        let window = JubjubBls12::pedersen_hash_exp_window_size();
+        let window = params.pedersen_hash_exp_window_size();
         let window_mask = (1 << window) - 1;
 
         let mut acc = acc.into_repr();


### PR DESCRIPTION
Based on analaysis in https://github.com/filecoin-project/rust-fil-proofs/issues/697 and comments in https://github.com/filecoin-project/rust-fil-proofs/issues/736, it seems clear that bumping the `pedersen_hash_exp_window_size` from 8 to 16 as the default is a safe change worthwhile making no matter what. This accomplishes a ~1.7X speedup of pedersen hashes outside of circuits, with an apparent measured impact of only ~50K on max memory usage.

Therefore, rather than sit on this optimization which will be useful for other efforts and general momentum, let's change the default now but still continue with https://github.com/filecoin-project/rust-fil-proofs/issues/736 so we can further refine the optimal setting and allow a greater range of options for when we start trying to derive 'final' configurations.