### PR TITLE
feat(pedersen-hash): add file-backed exp-table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ paired =  { version = "0.16.0", features = ["expose-arith"] }
 bellperson = "0.4.0"
 blake2b_simd = "0.5"
 blake2s_simd = "0.5"
+lazy_static = "1.4.0"
+rayon = "1.2.0"
 
 [dev-dependencies]
 digest = "0.8"

--- a/src/jubjub/edwards.rs
+++ b/src/jubjub/edwards.rs
@@ -7,6 +7,7 @@ use rand_core::RngCore;
 
 use std::marker::PhantomData;
 
+use std::fmt::{self, Debug, Formatter};
 use std::io::{self, Read, Write};
 
 // Represents the affine point (X/Z, Y/Z) via the extended
@@ -67,6 +68,8 @@ impl<E: JubjubEngine, Subgroup> PartialEq for Point<E, Subgroup> {
         x1 == x2 && y1 == y2
     }
 }
+
+impl<E: JubjubEngine, Subgroup> Eq for Point<E, Subgroup> {}
 
 impl<E: JubjubEngine> Point<E, Unknown> {
     pub fn read<R: Read>(reader: R, params: &E::Params) -> io::Result<Self> {
@@ -485,9 +488,30 @@ impl<E: JubjubEngine, Subgroup> Point<E, Subgroup> {
     }
 }
 
+#[derive(Clone)]
 pub struct CompressedPoint<E, Subgroup>(<E::Fr as PrimeField>::Repr, PhantomData<Subgroup>)
 where
     E: JubjubEngine;
+
+impl<E, Subgroup> Debug for CompressedPoint<E, Subgroup>
+where
+    E: JubjubEngine,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_tuple("CompressedPoint").field(&self.0).finish()
+    }
+}
+
+impl<E, Subgroup> PartialEq for CompressedPoint<E, Subgroup>
+where
+    E: JubjubEngine,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<E: JubjubEngine, Subgroup> Eq for CompressedPoint<E, Subgroup> {}
 
 impl<E, Subgroup> CompressedPoint<E, Subgroup>
 where

--- a/src/jubjub/mod.rs
+++ b/src/jubjub/mod.rs
@@ -16,16 +16,19 @@
 //! It is a complete twisted Edwards curve, so the equivalence with
 //! the Montgomery curve forms a group isomorphism, allowing points
 //! to be freely converted between the two forms.
-
-use paired::Engine;
+use std::fs::{create_dir_all, File, OpenOptions};
+use std::io::{self, BufReader, Read, Seek, SeekFrom, Write};
+use std::mem::size_of;
+use std::path::Path;
 
 use ff::{Field, PrimeField, SqrtField};
-
-use crate::group_hash::group_hash;
+use lazy_static::lazy_static;
+use paired::bls12_381::{Bls12, Fr};
+use paired::Engine;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::constants;
-
-use paired::bls12_381::{Bls12, Fr};
+use crate::group_hash::group_hash;
 
 /// This is an implementation of the twisted Edwards Jubjub curve.
 pub mod edwards;
@@ -39,6 +42,28 @@ pub mod fs;
 
 #[cfg(test)]
 pub mod tests;
+
+pub const MAX_EXP_TABLE_SEGMENTS_IN_MEMORY: usize = 50;
+
+lazy_static! {
+    // The interface for the Edward's curve group law requires that the curve's `d` parameter be
+    // passed in using a type that implements `JubjubParams`. This static value creates a structure
+    // that contains only the Edward's curve `d` parameter, which can then be passed into Edward's
+    // point addition (and multiplication).
+    static ref JUBJUB_BLS12_PARAMS_WITH_EDWARDS_D: JubjubBls12 = JubjubBls12 {
+        edwards_d: Fr::from_str("19257038036680949359750312669786877991949435402254120286184196891950884077233").unwrap(),
+        pedersen_hash_exp_window_size_supplied: 0,
+        pedersen_hash_exp: vec![],
+        montgomery_a: Fr::zero(),
+        montgomery_2a: Fr::zero(),
+        scale: Fr::zero(),
+        pedersen_hash_generators: vec![],
+        pedersen_circuit_generators: vec![],
+        fixed_base_generators: vec![],
+        fixed_base_circuit_generators: vec![],
+        exp_table_path: None,
+    };
+}
 
 /// Point of unknown order.
 pub enum Unknown {}
@@ -125,6 +150,10 @@ pub trait JubjubParams<E: JubjubEngine>: Sized {
     /// Returns the window size for exponentiation of Pedersen hash generators
     /// outside the circuit
     fn pedersen_hash_exp_window_size(&self) -> u32;
+
+    /// If these parameters use a file-backed Pedersen Hash exp-table, returns the path to the
+    /// exp-table file.
+    fn exp_table_path(&self) -> &Option<String>;
 }
 
 impl JubjubEngine for Bls12 {
@@ -132,6 +161,7 @@ impl JubjubEngine for Bls12 {
     type Params = JubjubBls12;
 }
 
+#[derive(Clone)]
 pub struct JubjubBls12 {
     edwards_d: Fr,
     montgomery_a: Fr,
@@ -145,6 +175,8 @@ pub struct JubjubBls12 {
     fixed_base_generators: Vec<edwards::Point<Bls12, PrimeOrder>>,
     fixed_base_circuit_generators: Vec<Vec<Vec<(Fr, Fr)>>>,
     pedersen_hash_exp_window_size_supplied: u32,
+
+    exp_table_path: Option<String>,
 }
 
 impl JubjubParams<Bls12> for JubjubBls12 {
@@ -184,14 +216,29 @@ impl JubjubParams<Bls12> for JubjubBls12 {
     fn pedersen_hash_exp_window_size(&self) -> u32 {
         self.pedersen_hash_exp_window_size_supplied
     }
+
+    fn exp_table_path(&self) -> &Option<String> {
+        &self.exp_table_path
+    }
 }
 
 impl JubjubBls12 {
     pub fn new() -> Self {
-        Self::new_with_window_size(8)
+        Self::new_with_n_segments_and_window_size(5, 8, None).unwrap()
     }
 
     pub fn new_with_window_size(window_size: u32) -> Self {
+        Self::new_with_n_segments_and_window_size(5, window_size, None).unwrap()
+    }
+
+    /// Returns an `Err` if we failed to create `exp_table_path` (create the directories in the path
+    /// that do not exist) or if we fail to create the exp-table file. An `Err` will never be
+    /// returned if the `exp_table_path` argument is `None`.
+    pub fn new_with_n_segments_and_window_size(
+        n_segments: usize,
+        window_size: u32,
+        exp_table_path: Option<&str>,
+    ) -> io::Result<Self> {
         let montgomery_a = Fr::from_str("40962").unwrap();
         let mut montgomery_2a = montgomery_a;
         montgomery_2a.double();
@@ -212,13 +259,15 @@ impl JubjubBls12 {
             )
             .unwrap(),
 
-            // We'll initialize these below
+            // We'll initialize these vectors below.
             pedersen_hash_generators: vec![],
             pedersen_hash_exp: vec![],
             pedersen_circuit_generators: vec![],
             fixed_base_generators: vec![],
             fixed_base_circuit_generators: vec![],
+
             pedersen_hash_exp_window_size_supplied: window_size,
+            exp_table_path: exp_table_path.map(|path| path.to_string()),
         };
 
         fn find_group_hash<E: JubjubEngine>(
@@ -247,7 +296,7 @@ impl JubjubBls12 {
         {
             let mut pedersen_hash_generators = vec![];
 
-            for m in 0..5 {
+            for m in 0..n_segments as u32 {
                 use byteorder::{LittleEndian, WriteBytesExt};
 
                 let mut segment_number = [0u8; 4];
@@ -279,39 +328,19 @@ impl JubjubBls12 {
         }
 
         // Create the exp table for the Pedersen hash generators
-        {
-            let mut pedersen_hash_exp = vec![];
-
-            for g in &tmp_params.pedersen_hash_generators {
-                let mut g = g.clone();
-
-                let window = window_size;
-
-                let mut tables = vec![];
-
-                let mut num_bits = 0;
-                while num_bits <= fs::Fs::NUM_BITS {
-                    let mut table = Vec::with_capacity(1 << window);
-
-                    let mut base = edwards::Point::zero();
-
-                    for _ in 0..(1 << window) {
-                        table.push(base.clone());
-                        base = base.add(&g, &tmp_params);
-                    }
-
-                    tables.push(table);
-                    num_bits += window;
-
-                    for _ in 0..window {
-                        g = g.double(&tmp_params);
-                    }
-                }
-
-                pedersen_hash_exp.push(tables);
+        if let Some(path) = exp_table_path {
+            if must_write_exp_table(n_segments, window_size, path) {
+                write_exp_table_to_file(&tmp_params.pedersen_hash_generators, window_size, path)?;
             }
-
-            tmp_params.pedersen_hash_exp = pedersen_hash_exp;
+            // As an optimization, always keep the first 5 segments worth of the exp-table in main
+            // memory.
+            tmp_params.pedersen_hash_exp = create_exp_table_for_generators(
+                &tmp_params.pedersen_hash_generators[..5],
+                window_size,
+            );
+        } else {
+            tmp_params.pedersen_hash_exp =
+                create_exp_table_for_generators(&tmp_params.pedersen_hash_generators, window_size);
         }
 
         // Create the bases for other parts of the protocol
@@ -430,8 +459,277 @@ impl JubjubBls12 {
             tmp_params.fixed_base_circuit_generators = fixed_base_circuit_generators;
         }
 
-        tmp_params
+        Ok(tmp_params)
     }
+}
+
+/// Determines whether or not we have to write/overwrite the exp-table file at `exp_table_path`.
+///
+/// If the exp-table file at `exp_table_path` exists and has the correct metadata (number of
+/// segments and window-size) that is desired for these Pedersen Hash params, we return `false` to
+/// indicate that no further exp-table generation needs to take place.
+///
+/// If the file doesn't exist, is not long enough (the number of segments in the exp-table file is
+/// fewer than the number of segments required by the Pedersen Hash params), or the window-size in
+/// the file differs from that being requested, we return `true` to indicate that a new exp-table
+/// must be generated and written.
+fn must_write_exp_table(
+    n_segments_required: usize,
+    window_size_required: u32,
+    exp_table_path: &str,
+) -> bool {
+    let mut file = match File::open(exp_table_path) {
+        Ok(file) => file,
+        _ => return true,
+    };
+
+    let n_segments_in_file = {
+        let mut buf = [0u8; 4];
+        if file.read_exact(&mut buf).is_err() {
+            return true;
+        }
+        u32::from_le_bytes(buf) as usize
+    };
+
+    if n_segments_in_file < n_segments_required {
+        return true;
+    }
+
+    let window_size_in_file = {
+        file.seek(SeekFrom::Start(4)).unwrap();
+        let mut buf = [0u8; 4];
+        if file.read_exact(&mut buf).is_err() {
+            return true;
+        }
+        u32::from_le_bytes(buf)
+    };
+
+    window_size_in_file != window_size_required
+}
+
+/// Create the exp-table for the provided set of generators.
+fn create_exp_table_for_generators(
+    generators: &[edwards::Point<Bls12, PrimeOrder>],
+    window_size: u32,
+) -> Vec<Vec<Vec<edwards::Point<Bls12, PrimeOrder>>>> {
+    let mut exp_table = Vec::with_capacity(generators.len());
+    let n_windows_per_segment = (fs::Fs::NUM_BITS as f32 / window_size as f32).ceil() as usize;
+
+    for g in generators.iter() {
+        let mut g = g.clone();
+        let mut segment_windows = Vec::with_capacity(n_windows_per_segment);
+
+        let mut num_bits = 0;
+        while num_bits <= fs::Fs::NUM_BITS {
+            let mut window_values = Vec::with_capacity(1 << window_size);
+            let mut base = edwards::Point::zero();
+
+            for _ in 0..(1 << window_size) {
+                window_values.push(base.clone());
+                base = base.add(&g, &JUBJUB_BLS12_PARAMS_WITH_EDWARDS_D);
+            }
+
+            segment_windows.push(window_values);
+            num_bits += window_size;
+
+            for _ in 0..window_size {
+                g = g.double(&JUBJUB_BLS12_PARAMS_WITH_EDWARDS_D);
+            }
+        }
+
+        exp_table.push(segment_windows);
+    }
+
+    exp_table
+}
+
+/// Given a path to an exp-table file, this function creates any directories in that path that do
+/// not exist.
+fn create_exp_table_path_if_dne(path: &str) -> io::Result<()> {
+    let path = Path::new(path);
+    let dirs = path.parent().expect("invalid exp-table path");
+    let path_is_just_file_name = dirs.to_str().unwrap().is_empty();
+
+    if path_is_just_file_name {
+        Ok(())
+    } else {
+        create_dir_all(dirs)
+    }
+}
+
+/// Generates the Pedersen Hash parameter's exp-table in chunks of segments, writing each chunk of
+/// the exp-table to the file at `exp_table_path`. This function generates the exp-table in such a
+/// way that there is never more than `MAX_EXP_TABLE_SEGMENTS_IN_MEMORY` segments worth of the
+/// exp-table in memory at a given time.
+///
+/// Returns an `Err` if we failed to create `exp_table_path` (create the directories in the path
+/// that do not exist) or if we fail to create the exp-table file.
+fn write_exp_table_to_file(
+    generators: &[edwards::Point<Bls12, PrimeOrder>],
+    window_size: u32,
+    exp_table_path: &str,
+) -> io::Result<()> {
+    create_exp_table_path_if_dne(exp_table_path)?;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(exp_table_path)?;
+
+    // The first 8 bytes of the exp-table file are the number of segments in the exp-table (4 bytes)
+    // and the window-size for this exp-table (4 bytes).
+    let n_segments = generators.len();
+    let n_segments_as_bytes = (n_segments as u32).to_le_bytes();
+    let window_size_as_bytes = window_size.to_le_bytes();
+    file.write_all(&n_segments_as_bytes)
+        .expect("failed to write n_segments");
+    file.write_all(&window_size_as_bytes)
+        .expect("failed to write window_size");
+
+    let mut n_segments_written = 0;
+
+    // Generate and write the exp-table in chunks.
+    while n_segments_written < n_segments {
+        let n_segments_remaining = n_segments - n_segments_written;
+
+        // The number of segments of the exp-table being generated in this chunk. It is possible for
+        // the last chunk to contain fewer than `MAX_EXP_TABLE_SEGMENTS_IN_MEMORY` number of
+        // segments of the exp-table.
+        let n_segments_in_range = if n_segments_remaining > MAX_EXP_TABLE_SEGMENTS_IN_MEMORY {
+            MAX_EXP_TABLE_SEGMENTS_IN_MEMORY
+        } else {
+            n_segments_remaining
+        };
+
+        // Calculate the range of segment indices for this chunk, create the generators
+        // corresponding to each segment index, then create the exp-table corresponding to each of
+        // the generators.
+        let first_segment = n_segments_written;
+        let stop_at_segment = first_segment + n_segments_in_range;
+        let generators = &generators[first_segment..stop_at_segment];
+        let exp_table = create_exp_table_for_generators(generators, window_size);
+
+        // For each segment in this chunk, compress the segment's exp-table values (Edward points)
+        // in parallel. Collect into a vector then write to the exp-table file to reduce the number
+        // of file I/O operations.
+        for segment_table in exp_table {
+            let segment_table_bytes: Vec<u8> = segment_table
+                .par_iter()
+                .flat_map(|window| {
+                    window
+                        .par_iter()
+                        .flat_map(|point| point.compress().as_bytes())
+                        .collect::<Vec<u8>>()
+                })
+                .collect();
+
+            file.write_all(&segment_table_bytes)
+                .expect("failed to write segment table bytes");
+        }
+
+        n_segments_written += n_segments_in_range;
+    }
+
+    Ok(())
+}
+
+/// Loads into memory a range of the exp-table file. The range of the exp-table file that is read is
+/// given by the range of segment indices: `first_segment..first_segment + n_segments`.
+///
+/// This function can return less than `n_segments` worth of the exp-table if `first_segment +
+/// n_segments` exceeds the length of the exp-table file. If `first_segment` exceeds the number of
+/// segments in the exp-table file an empty vector is returned. It is the user's responsibility to
+/// check the number of exp-table segments returned from this function.
+///
+/// Returns an `Err` if there is no file at `exp_table_path` or the file cannot be read.
+pub fn read_exp_table_range(
+    first_segment: usize,
+    n_segments: usize,
+    exp_table_path: &str,
+) -> io::Result<Vec<Vec<Vec<edwards::Point<Bls12, PrimeOrder>>>>> {
+    let file = File::open(exp_table_path)?;
+
+    // We wrap the exp-table file in `BufReader` to lessen the cost of many file reads.
+    let mut reader = BufReader::new(file);
+
+    // We skip the first 4 bytes in the file because those bytes encode the number of segments in
+    // the file (which is a value that we will not use in this function).
+    reader.seek(SeekFrom::Start(4)).unwrap();
+
+    let window_size = {
+        let mut buf = [0u8; 4];
+        reader
+            .read_exact(&mut buf)
+            .expect("failed to read bytes 4-8 from the exp-table file");
+        u32::from_le_bytes(buf)
+    };
+
+    // Calculate the number of bytes we have to seek forward per segment in the exp-table file.
+    let n_windows_per_segment = {
+        let n_windows_per_segment = fs::Fs::NUM_BITS as f32 / window_size as f32;
+        if n_windows_per_segment.fract() == 0.0 {
+            (n_windows_per_segment as usize) + 1
+        } else {
+            n_windows_per_segment.ceil() as usize
+        }
+    };
+    let n_points_per_window = 2usize.pow(window_size);
+    let n_bytes_per_point = size_of::<Fr>();
+    let n_bytes_per_segment = n_windows_per_segment * n_points_per_window * n_bytes_per_point;
+
+    // Seek to the first byte in the exp-table that we want to read.
+    let n_exp_table_bytes_to_skip = n_bytes_per_segment as i64 * first_segment as i64;
+    reader
+        .seek(SeekFrom::Current(n_exp_table_bytes_to_skip))
+        .unwrap();
+
+    // TODO: parallelize exp-reads - start by trying to read one segment per thread if `n_segments`
+    // is small.
+
+    // Read in the desired range of the exp-table.
+    let mut exp_table = vec![];
+
+    for _ in 0..n_segments {
+        let mut segment_windows = vec![];
+        for _ in 0..n_windows_per_segment {
+            let mut window = vec![];
+            for _ in 0..n_points_per_window {
+                let read_point_res = edwards::Point::<Bls12, Unknown>::read(
+                    &mut reader,
+                    &JUBJUB_BLS12_PARAMS_WITH_EDWARDS_D,
+                );
+
+                let point = match read_point_res {
+                    Ok(point) => point
+                        .as_prime_order(&JUBJUB_BLS12_PARAMS_WITH_EDWARDS_D)
+                        .expect("point read from exp-table does not belong to subgroup"),
+                    Err(err) => {
+                        match err.kind() {
+                            io::ErrorKind::UnexpectedEof => {
+                                // If we have reached the end of the file and have successfully read
+                                // the last segment's table, return the exp-table. Otherwise, if we
+                                // have reached the end of the exp-table file in the middle of a
+                                // segment's table, panic.
+                                if segment_windows.is_empty() && window.is_empty() {
+                                    return Ok(exp_table);
+                                }
+                                panic!("exp-table file ends in the middle of a segment's table");
+                            }
+                            _ => {
+                                panic!("point read from exp-table does not exist on curve");
+                            }
+                        }
+                    }
+                };
+
+                window.push(point);
+            }
+            segment_windows.push(window);
+        }
+        exp_table.push(segment_windows);
+    }
+
+    Ok(exp_table)
 }
 
 #[test]

--- a/src/jubjub/mod.rs
+++ b/src/jubjub/mod.rs
@@ -69,6 +69,7 @@ lazy_static! {
 pub enum Unknown {}
 
 /// Point of prime order.
+#[derive(Clone)]
 pub enum PrimeOrder {}
 
 /// Fixed generators of the Jubjub curve of unknown


### PR DESCRIPTION
In this PR:
- creating Pedersen Hash parameters of any size (number of segments) `JubjubBls12::new_with_n_segments_and_window_size()`
- reading and writing Pedersen Hash exponentiation table from disk
- passing in the Pedersen Hash exponentiation table as an argument to the pedersen hash `pedersen_hash_with_exp_table()`
- Edward's point compression and decompression
- adds `bitvec` and `rayon` dependencies